### PR TITLE
Feature/3 page selected call twice

### DIFF
--- a/app/src/main/java/com/kenilt/loopingviewpager/example/fragmentPager/FragmentPagerExampleActivity.kt
+++ b/app/src/main/java/com/kenilt/loopingviewpager/example/fragmentPager/FragmentPagerExampleActivity.kt
@@ -15,6 +15,7 @@ class FragmentPagerExampleActivity : BaseExampleActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_fragment_pager_example)
 
+        // View pager adapter and indicator
         vpPager.setAdapter(
             ExampleFragmentPagerAdapter(
                 supportFragmentManager,
@@ -23,10 +24,21 @@ class FragmentPagerExampleActivity : BaseExampleActivity() {
         )
         indicator.setViewPager(vpPager)
 
+        // Auto scroll
+        val autoScroller = AutoScroller(vpPager, lifecycle, 3000)
+        swAutoScroll.setOnCheckedChangeListener { _, isChecked ->
+            autoScroller.isAutoScroll = isChecked
+        }
+
+        // Other
+        initRelatedViews()
+    }
+
+    private fun initRelatedViews() {
         btnPrevious.setOnClickListener { vpPager.setCurrentItem(vpPager.currentItem - 1, true) }
         btnNext.setOnClickListener { vpPager.setCurrentItem(vpPager.currentItem + 1, true) }
 
-        seekBar.setOnSeekBarChangeListener(object: SeekBar.OnSeekBarChangeListener {
+        seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
                 val count = progress + 1
                 txtItemCount.text = "Item count:   $count"
@@ -40,12 +52,6 @@ class FragmentPagerExampleActivity : BaseExampleActivity() {
 
             override fun onStopTrackingTouch(seekBar: SeekBar?) {}
         })
-
-        // auto scroll
-        val autoScroller = AutoScroller(vpPager, lifecycle, 3000)
-        swAutoScroll.setOnCheckedChangeListener { _, isChecked ->
-            autoScroller.isAutoScroll = isChecked
-        }
     }
 
     override fun getTitleId(): Int {

--- a/app/src/main/java/com/kenilt/loopingviewpager/example/fragmentStatePager/FragmentStatePagerExampleActivity.kt
+++ b/app/src/main/java/com/kenilt/loopingviewpager/example/fragmentStatePager/FragmentStatePagerExampleActivity.kt
@@ -15,6 +15,7 @@ class FragmentStatePagerExampleActivity : BaseExampleActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_fragment_state_pager_example)
 
+        // View pager adapter and indicator
         vpPager.setAdapter(
             ExampleFragmentStatePagerAdapter(
                 supportFragmentManager,
@@ -23,10 +24,21 @@ class FragmentStatePagerExampleActivity : BaseExampleActivity() {
         )
         indicator.setViewPager(vpPager)
 
+        // Auto scroll
+        val autoScroller = AutoScroller(vpPager, lifecycle, 3000)
+        swAutoScroll.setOnCheckedChangeListener { _, isChecked ->
+            autoScroller.isAutoScroll = isChecked
+        }
+
+        // Others
+        initRelatedViews()
+    }
+
+    private fun initRelatedViews() {
         btnPrevious.setOnClickListener { vpPager.setCurrentItem(vpPager.currentItem - 1, true) }
         btnNext.setOnClickListener { vpPager.setCurrentItem(vpPager.currentItem + 1, true) }
 
-        seekBar.setOnSeekBarChangeListener(object: SeekBar.OnSeekBarChangeListener {
+        seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
                 val count = progress + 1
                 txtItemCount.text = "Item count:   $count"
@@ -40,12 +52,6 @@ class FragmentStatePagerExampleActivity : BaseExampleActivity() {
 
             override fun onStopTrackingTouch(seekBar: SeekBar?) {}
         })
-
-        // auto scroll
-        val autoScroller = AutoScroller(vpPager, lifecycle, 3000)
-        swAutoScroll.setOnCheckedChangeListener { _, isChecked ->
-            autoScroller.isAutoScroll = isChecked
-        }
     }
 
     override fun getTitleId(): Int {

--- a/app/src/main/java/com/kenilt/loopingviewpager/example/showHideFragmentExample/ShowHideFragmentActivity.kt
+++ b/app/src/main/java/com/kenilt/loopingviewpager/example/showHideFragmentExample/ShowHideFragmentActivity.kt
@@ -1,11 +1,11 @@
 package com.kenilt.loopingviewpager.example.showHideFragmentExample
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import com.kenilt.loopingviewpager.example.BaseExampleActivity
 import com.kenilt.loopingviewpager.example.R
 import kotlinx.android.synthetic.main.activity_show_hide_fragment.*
 
-class ShowHideFragmentActivity : AppCompatActivity() {
+class ShowHideFragmentActivity : BaseExampleActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -25,5 +25,9 @@ class ShowHideFragmentActivity : AppCompatActivity() {
                 supportFragmentManager.beginTransaction().hide(simpleExampleFragment).commit()
             }
         }
+    }
+
+    override fun getTitleId(): Int {
+        return R.string.show_hide_fragment_example
     }
 }

--- a/app/src/main/java/com/kenilt/loopingviewpager/example/simpleExample/SimpleExampleActivity.kt
+++ b/app/src/main/java/com/kenilt/loopingviewpager/example/simpleExample/SimpleExampleActivity.kt
@@ -14,16 +14,28 @@ class SimpleExampleActivity : BaseExampleActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_simple_example)
 
+        // View pager adapter and indicator
         vpPager.adapter = ExamplePagerAdapter(
             this,
             DataGenerator.generateList()
         )
         indicator.setViewPager(vpPager)
 
+        // Auto scroll
+        val autoScroller = AutoScroller(vpPager, lifecycle, 3000)
+        swAutoScroll.setOnCheckedChangeListener { _, isChecked ->
+            autoScroller.isAutoScroll = isChecked
+        }
+
+        // Others
+        initRelatedViews()
+    }
+
+    private fun initRelatedViews() {
         btnPrevious.setOnClickListener { vpPager.setCurrentItem(vpPager.currentItem - 1, true) }
         btnNext.setOnClickListener { vpPager.setCurrentItem(vpPager.currentItem + 1, true) }
 
-        seekBar.setOnSeekBarChangeListener(object: SeekBar.OnSeekBarChangeListener {
+        seekBar.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
                 val count = progress + 1
                 txtItemCount.text = "Item count:   $count"
@@ -37,12 +49,6 @@ class SimpleExampleActivity : BaseExampleActivity() {
 
             override fun onStopTrackingTouch(seekBar: SeekBar?) {}
         })
-
-        // auto scroll
-        val autoScroller = AutoScroller(vpPager, lifecycle, 3000)
-        swAutoScroll.setOnCheckedChangeListener { _, isChecked ->
-            autoScroller.isAutoScroll = isChecked
-        }
     }
 
     override fun getTitleId(): Int {

--- a/loopingviewpager/src/main/java/com/kenilt/loopingviewpager/util/LoopingUtil.kt
+++ b/loopingviewpager/src/main/java/com/kenilt/loopingviewpager/util/LoopingUtil.kt
@@ -34,20 +34,4 @@ object LoopingUtil {
             else -> internalPosition - 1
         }
     }
-
-    /**
-     * Convert internal position to pager position for paged selected
-     * The index out of range will be return -1
-     *
-     * @param originalAdapter is the adapter which was defined by outer
-     * @param internalPosition is the internal position
-     */
-    fun getPagerPositionForSelected(originalAdapter: PagerAdapter?, internalPosition: Int): Int {
-        val count = originalAdapter?.count ?: 0
-        return when (internalPosition) {
-            0 -> -1
-            count + 1 -> -1
-            else -> internalPosition - 1
-        }
-    }
 }

--- a/loopingviewpager/src/main/java/com/kenilt/loopingviewpager/util/LoopingUtil.kt
+++ b/loopingviewpager/src/main/java/com/kenilt/loopingviewpager/util/LoopingUtil.kt
@@ -34,4 +34,20 @@ object LoopingUtil {
             else -> internalPosition - 1
         }
     }
+
+    /**
+     * Convert internal position to pager position for paged selected
+     * The index out of range will be return -1
+     *
+     * @param originalAdapter is the adapter which was defined by outer
+     * @param internalPosition is the internal position
+     */
+    fun getPagerPositionForSelected(originalAdapter: PagerAdapter?, internalPosition: Int): Int {
+        val count = originalAdapter?.count ?: 0
+        return when (internalPosition) {
+            0 -> -1
+            count + 1 -> -1
+            else -> internalPosition - 1
+        }
+    }
 }

--- a/loopingviewpager/src/main/java/com/kenilt/loopingviewpager/widget/InternalOnPageChangeListener.kt
+++ b/loopingviewpager/src/main/java/com/kenilt/loopingviewpager/widget/InternalOnPageChangeListener.kt
@@ -9,6 +9,8 @@ internal class InternalOnPageChangeListener(
     private val adapterGetter: () -> PagerAdapter?
 ) : ViewPager.OnPageChangeListener {
 
+    private var lastOuterIndex = -1
+
     override fun onPageScrollStateChanged(state: Int) {
         pageChangeListener.onPageScrollStateChanged(state)
     }
@@ -31,9 +33,26 @@ internal class InternalOnPageChangeListener(
     }
 
     override fun onPageSelected(position: Int) {
-        val selectedIndex = LoopingUtil.getPagerPositionForSelected(adapterGetter.invoke(), position)
-        if (selectedIndex >= 0) {
-            pageChangeListener.onPageSelected(selectedIndex)
+        val originalAdapter = adapterGetter.invoke() ?: return
+        val pagerPosition = LoopingUtil.getPagerPosition(originalAdapter, position)
+
+        when {
+            // if the index is the first or last item, fire the event and assign flag
+            // originalAdapter.count + 1 means the last item of internal adapter
+            position == 0 || position == originalAdapter.count + 1 -> {
+                pageChangeListener.onPageSelected(pagerPosition)
+                lastOuterIndex = pagerPosition
+            }
+            // if the pager position is duplicate with the previous outer, it means this position
+            // was selected in the last time, so no need to fire event again, just clear the flag
+            pagerPosition == lastOuterIndex -> {
+                lastOuterIndex = -1
+            }
+            // for normal case, fire the event and clear the flag
+            else -> {
+                pageChangeListener.onPageSelected(pagerPosition)
+                lastOuterIndex = -1
+            }
         }
     }
 }

--- a/loopingviewpager/src/main/java/com/kenilt/loopingviewpager/widget/InternalOnPageChangeListener.kt
+++ b/loopingviewpager/src/main/java/com/kenilt/loopingviewpager/widget/InternalOnPageChangeListener.kt
@@ -31,11 +31,9 @@ internal class InternalOnPageChangeListener(
     }
 
     override fun onPageSelected(position: Int) {
-        pageChangeListener.onPageSelected(
-            LoopingUtil.getPagerPosition(
-                adapterGetter.invoke(),
-                position
-            )
-        )
+        val selectedIndex = LoopingUtil.getPagerPositionForSelected(adapterGetter.invoke(), position)
+        if (selectedIndex >= 0) {
+            pageChangeListener.onPageSelected(selectedIndex)
+        }
     }
 }


### PR DESCRIPTION
Prevent onPageSelected() event was called twice at the first and last items.
Refactor sample, make it easier know how to use this library.

Fix #3 as well.